### PR TITLE
Add release context, to help it update Github?

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ workflows:
     jobs:
       - test
       - release:
+          context: frontend-deploy-library
           requires:
             - test
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ workflows:
     jobs:
       - test
       - release:
-          context: frontend-deploy-library
+          context: frontend-publish
           requires:
             - test
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.4
+
+## Fix build
+
 # v1.2.3
 
 ## Allow multiple newlines between tagName and releaseTitle to account for Prettier rule

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-to-github-with-changelog",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-to-github-with-changelog",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Parses CHANGELOG.md to publish a new release resource to the Github api",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Release build is failing when trying to push release information to GitHub: https://circleci.com/gh/transferwise/release-to-github-with-changelog/111

Maybe it needs this context?